### PR TITLE
Lancer les migrations automatiquement à chaque déploiement

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+postdeploy: python manage.py migrate
 web: gunicorn aidants_connect_carto.wsgi --log-file -


### PR DESCRIPTION
## Objectif

Lancer les migrations automatiquement sur Scalingo. Cela evite de devoir se connecter à l'instance à chaque déploiement qui implique une migration du modèle de donnée.

## Implémentation

Ajout d'un postdeploy au Procfile