### PR TITLE
Ajoute un lien vers le schéma de données

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,12 @@
         <h1>Cartographie Aidants Connect</h1>
         <p>
           Ce service a été abandonné en l'état, mais un successeur est en
-          préparation.
+          préparation sur la base de
+          <a
+            href="https://schema.data.gouv.fr/etalab/schema-inclusion-numerique/latest.html"
+          >
+            ce schéma de données.
+          </a>
         </p>
         <p>
           Prenez contact avec societe.numerique (at) anct.gouv.fr pour toute
@@ -96,6 +101,23 @@
                   </h2>
                   <p class="fr-card__desc">
                     En savoir plus sur le service Aidants Connect
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div class="fr-col-12 fr-col-md-3">
+              <div class="fr-card fr-enlarge-link">
+                <div class="fr-card__body">
+                  <h2 class="fr-card__title">
+                    <a
+                      href="https://schema.data.gouv.fr/etalab/schema-inclusion-numerique/latest.html"
+                    >
+                      Schéma des lieux d'inclusion numérique
+                    </a>
+                  </h2>
+                  <p class="fr-card__desc">
+                    Ce schéma permet de modéliser les lieux d’accès au numérique
+                    sur tout le territoire.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Objectif

Rendre la page "carto" plus utile.

## Implémentation

Ajout d'un lien vers la page officielle du schéma.

## Images

![Capture d’écran 2021-07-12 à 09 26 40-fullpage](https://user-images.githubusercontent.com/1035145/125247680-81f24280-e2f3-11eb-89d9-9ae1347e368f.png)
